### PR TITLE
test: add UI tests for search and rxnorm filtering

### DIFF
--- a/tests/test_static_site.py
+++ b/tests/test_static_site.py
@@ -1,7 +1,6 @@
 import unittest
 from pathlib import Path
 
-
 class StaticSiteTests(unittest.TestCase):
     def test_dashboard_keyboard_shortcuts_are_wired(self):
         app_js = Path("site/app.js").read_text(encoding="utf-8")
@@ -9,9 +8,19 @@ class StaticSiteTests(unittest.TestCase):
         self.assertIn('event.key === "/"', app_js)
         self.assertIn('event.key === "Escape"', app_js)
         self.assertIn("!isEditableTarget(event.target)", app_js)
-        self.assertIn("document.addEventListener(\"keydown\", handleKeyboardShortcuts)", app_js)
+        self.assertIn('document.addEventListener("keydown", handleKeyboardShortcuts)', app_js)
 
+    def test_dashboard_search_filtering_is_wired(self):
+        app_js = Path("site/app.js").read_text(encoding="utf-8")
+        self.assertIn("function filteredRecords()", app_js)
+        self.assertIn("function setQuery(value)", app_js)
+        self.assertIn('elements.searchInput.addEventListener("input"', app_js)
+
+    def test_dashboard_rxnorm_selection_is_wired(self):
+        app_js = Path("site/app.js").read_text(encoding="utf-8")
+        self.assertIn("async function resolveRxNorm()", app_js)
+        self.assertIn("function renderRxNormPanel(records)", app_js)
+        self.assertIn('elements.rxnormButton.addEventListener("click", resolveRxNorm)', app_js)
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary

Hi! I saw in the ROADMAP.md that you were looking for small UI tests for the search filtering and RxNorm candidate selection. I added two lightweight tests to `test_static_site.py` that verify the core JS functions and event listeners are properly wired up, following the existing pattern for the keyboard shortcuts. Tests are passing locally!

## Type of change

- [ ] Documentation
- [ ] Dashboard/UI
- [ ] Python/CLI
- [ ] Generated public data
- [x] Tests or tooling

## Public data safety

- [x] This uses public FDA/openFDA, NLM RxNorm, or other clearly public data only.
- [x] This does not add patient data, hospital data, vendor files, credentials, PHI, or private operational paths.
- [x] This does not add non-public scraping, private site automation, or license-restricted data.
- [x] Any generated data can be reproduced from public sources.

## Verification

- [x] I ran `python -m unittest discover -s tests`, or this is a docs-only change.
- [x] I checked that links or dashboard changes still work where applicable.