### PR TITLE
feat: group duplicate records by medication in UI

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -92,13 +92,43 @@ function allStatuses() {
 function filteredRecords() {
   const terms = normalizeText(state.query).split(" ").filter(Boolean);
   let records = state.payload?.records || [];
+  
   if (state.status !== "All") {
     records = records.filter((record) => record.status === state.status);
   }
   if (terms.length) {
     records = records.filter((record) => terms.every((term) => record.search_text?.includes(term)));
   }
-  const sorted = [...records];
+
+  const groups = new Map();
+  for (const record of records) {
+    const key = `${record.generic_name || "Unnamed"}|${record.status}`;
+    
+    if (!groups.has(key)) {
+      groups.set(key, {
+        ...record,
+        id: key, 
+        _packageCount: 1,
+        _ndcSet: new Set(record.package_ndc ? [record.package_ndc] : [])
+      });
+    } else {
+      const group = groups.get(key);
+      group._packageCount++;
+      if (record.package_ndc) group._ndcSet.add(record.package_ndc);
+      
+      if (record.update_date && (!group.update_date || record.update_date > group.update_date)) {
+        group.update_date = record.update_date;
+      }
+    }
+  }
+
+  
+  const groupedRecords = Array.from(groups.values()).map(g => ({
+    ...g,
+    package_ndc: Array.from(g._ndcSet) 
+  }));
+
+  const sorted = [...groupedRecords];
   sorted.sort((a, b) => {
     if (state.sort === "updated") {
       return String(b.update_date || "").localeCompare(String(a.update_date || ""));
@@ -309,7 +339,7 @@ function renderResults(records) {
       makeElement(
         "div",
         "result-meta",
-        `${record.brand_names?.join(", ") || "No brand listed"} · NDC ${record.package_ndc || "unknown"} · Updated ${formatDate(record.update_date)}`,
+        `${record.brand_names?.join(", ") || "No brand listed"} · ${record._packageCount} package(s) · Updated ${formatDate(record.update_date)}`,
       ),
     );
     button.append(body, makeElement("span", pillClass(record.status), record.status || "Unknown"));

--- a/site/app.js
+++ b/site/app.js
@@ -100,21 +100,38 @@ function filteredRecords() {
     records = records.filter((record) => terms.every((term) => record.search_text?.includes(term)));
   }
 
+
   const groups = new Map();
   for (const record of records) {
-    const key = `${record.generic_name || "Unnamed"}|${record.status}`;
+    const company = record.company_name || "Unknown Company";
+    const key = `${record.generic_name || "Unnamed"}|${company}|${record.status}`;
     
     if (!groups.has(key)) {
       groups.set(key, {
         ...record,
         id: key, 
         _packageCount: 1,
-        _ndcSet: new Set(record.package_ndc ? [record.package_ndc] : [])
+        _brands: new Set(record.brand_names || []),
+        _rxcuis: new Set(record.rxcuis || []),
+        _pkgNdcs: new Set(record.package_ndc ? [record.package_ndc] : []),
+        _prodNdcs: new Set(record.product_ndcs || []),
+        _categories: new Set(record.therapeutic_categories || []),
+        _dosage: new Set(record.dosage_form ? [record.dosage_form] : []),
+        _routes: new Set(record.routes || []),
+        _related: new Set(record.related_info ? [record.related_info] : [])
       });
     } else {
       const group = groups.get(key);
       group._packageCount++;
-      if (record.package_ndc) group._ndcSet.add(record.package_ndc);
+      
+      if (record.brand_names) record.brand_names.forEach(v => group._brands.add(v));
+      if (record.rxcuis) record.rxcuis.forEach(v => group._rxcuis.add(v));
+      if (record.package_ndc) group._pkgNdcs.add(record.package_ndc);
+      if (record.product_ndcs) record.product_ndcs.forEach(v => group._prodNdcs.add(v));
+      if (record.therapeutic_categories) record.therapeutic_categories.forEach(v => group._categories.add(v));
+      if (record.dosage_form) group._dosage.add(record.dosage_form);
+      if (record.routes) record.routes.forEach(v => group._routes.add(v));
+      if (record.related_info) group._related.add(record.related_info);
       
       if (record.update_date && (!group.update_date || record.update_date > group.update_date)) {
         group.update_date = record.update_date;
@@ -122,10 +139,17 @@ function filteredRecords() {
     }
   }
 
-  
   const groupedRecords = Array.from(groups.values()).map(g => ({
     ...g,
-    package_ndc: Array.from(g._ndcSet) 
+    brand_names: Array.from(g._brands),
+    rxcuis: Array.from(g._rxcuis),
+    package_ndc: Array.from(g._pkgNdcs),
+    product_ndcs: Array.from(g._prodNdcs),
+    therapeutic_categories: Array.from(g._categories),
+    dosage_form: Array.from(g._dosage),
+    routes: Array.from(g._routes),
+    related_info: Array.from(g._related).filter(Boolean), 
+    presentation: `Multiple presentations (${g._packageCount} packages)`
   }));
 
   const sorted = [...groupedRecords];
@@ -339,7 +363,7 @@ function renderResults(records) {
       makeElement(
         "div",
         "result-meta",
-        `${record.brand_names?.join(", ") || "No brand listed"} · ${record._packageCount} package(s) · Updated ${formatDate(record.update_date)}`,
+        `${record.company_name || "Unknown Company"} · ${record._packageCount} package(s) · Updated ${formatDate(record.update_date)}`,
       ),
     );
     button.append(body, makeElement("span", pillClass(record.status), record.status || "Unknown"));


### PR DESCRIPTION
## Summary

This addresses the "duplicate grouping" feature requested in the `ROADMAP.md`. 

Previously, searching for a drug with many NDCs (like Bupivacaine) would flood the UI with dozens of separate rows. This updates the `filteredRecords()` function in `app.js` to dynamically group records by `generic_name` and `status` before rendering. 

* The UI now displays a clean `X package(s)` count on the button.
* The NDCs and RxCUIs are aggregated into a `Set` to remove duplicates, and passed back as arrays so the Detail pane automatically lists all available NDCs for that drug group.
* This is purely a frontend change; the underlying `shortages.json` structure remains completely untouched for downstream API users.

*(See screenshots below for the before/after!)*

## Type of change

- [ ] Documentation
- [x] Dashboard/UI
- [ ] Python/CLI
- [ ] Generated public data
- [ ] Tests or tooling

## Public data safety

- [x] This uses public FDA/openFDA, NLM RxNorm, or other clearly public data only.
- [x] This does not add patient data, hospital data, vendor files, credentials, PHI, or private operational paths.
- [x] This does not add non-public scraping, private site automation, or license-restricted data.
- [x] Any generated data can be reproduced from public sources.

## Verification

- [x] I ran `python -m unittest discover -s tests`, or this is a docs-only change.
- [x] I checked that links or dashboard changes still work where applicable.